### PR TITLE
Improved error checking for normal tunnels

### DIFF
--- a/cmd/passage/application.go
+++ b/cmd/passage/application.go
@@ -46,7 +46,6 @@ const (
 	ConfigTunnelNormalSshUser           = "tunnel.normal.ssh_user"
 	ConfigTunnelNormalDialTimeout       = "tunnel.normal.dial.timeout"
 	ConfigTunnelNormalKeepaliveInterval = "tunnel.normal.keepalive_interval"
-	ConfigTunnelNormalKeepaliveTimeout  = "tunnel.normal.keepalive_timeout"
 
 	ConfigTunnelReverseEnabled  = "tunnel.reverse.enabled"
 	ConfigTunnelReverseHostKey  = "tunnel.reverse.host_key"
@@ -87,7 +86,6 @@ func initDefaults(config *viper.Viper) {
 	config.SetDefault(ConfigTunnelNormalSshUser, "passage")
 	config.SetDefault(ConfigTunnelNormalDialTimeout, 15*time.Second)
 	config.SetDefault(ConfigTunnelNormalKeepaliveInterval, 1*time.Minute)
-	config.SetDefault(ConfigTunnelNormalKeepaliveTimeout, 15*time.Second)
 	config.SetDefault(ConfigTunnelReverseBindHost, "0.0.0.0")
 	config.SetDefault(ConfigDiscoveryType, "static")
 	config.SetDefault(ConfigDiscoveryStaticHost, "localhost")

--- a/cmd/passage/server.go
+++ b/cmd/passage/server.go
@@ -75,7 +75,6 @@ func runTunnels(lc fx.Lifecycle, server tunnel.API, sql *sqlx.DB, config *viper.
 			User:              config.GetString(ConfigTunnelNormalSshUser),
 			DialTimeout:       config.GetDuration(ConfigTunnelNormalDialTimeout),
 			KeepaliveInterval: config.GetDuration(ConfigTunnelNormalKeepaliveInterval),
-			KeepaliveTimeout:  config.GetDuration(ConfigTunnelNormalKeepaliveTimeout),
 		}))
 	}
 

--- a/tunnel/conncheck.go
+++ b/tunnel/conncheck.go
@@ -78,7 +78,7 @@ func checkConnectivity(ctx context.Context, details ConnectionDetails) error {
 }
 
 // waitForTunnelError
-func waitForTunnelError(ctx context.Context, reader io.ReadCloser, duration time.Duration) error {
+func waitForTunnelError(ctx context.Context, reader io.ReadCloser, waitDuration time.Duration) error {
 	done := make(chan error)
 
 	// read in a context-aware fashion
@@ -100,7 +100,7 @@ func waitForTunnelError(ctx context.Context, reader io.ReadCloser, duration time
 	}()
 
 	select {
-	case <-time.After(duration):
+	case <-time.After(waitDuration):
 		return nil // success
 
 	case err := <-done:

--- a/tunnel/ssh.go
+++ b/tunnel/ssh.go
@@ -1,8 +1,11 @@
 package tunnel
 
 import (
+	"context"
 	"github.com/gliderlabs/ssh"
+	"github.com/pkg/errors"
 	gossh "golang.org/x/crypto/ssh"
+	"net"
 	"time"
 )
 
@@ -27,4 +30,50 @@ type SSHClientOptions struct {
 	User              string
 	DialTimeout       time.Duration
 	KeepaliveInterval time.Duration
+}
+
+// sshKeepaliver regularly sends a keepalive request and returns an error if there is a failure
+func sshKeepaliver(ctx context.Context, conn net.Conn, client *gossh.Client, interval, timeout time.Duration) error {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case <-ticker.C:
+			// Only break out of the keepaliver if we get an error
+			if err := sshKeepalivePing(ctx, conn, client, timeout); err != nil {
+				return err
+			}
+
+			// Reset deadline to the predicted next tick, plus a one-second grace period.
+			if err := conn.SetDeadline(time.Now().Add(interval + (1 * time.Second))); err != nil {
+				return errors.Wrap(err, "reset deadline")
+			}
+		}
+	}
+}
+
+// sshKeepalivePing sends a keepalive message and waits for a response, using the gossh client libraries
+func sshKeepalivePing(ctx context.Context, conn net.Conn, client *gossh.Client, timeout time.Duration) error {
+	// Set deadline for request.
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return errors.Wrap(err, "set conn deadline")
+	}
+
+	result := make(chan error)
+	go func() {
+		// Keepalive over the SSH connection
+		_, _, err := client.SendRequest("keepalive@passage", true, nil)
+		result <- err
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil
+	case err := <-result:
+		return err
+	}
 }

--- a/tunnel/ssh.go
+++ b/tunnel/ssh.go
@@ -27,5 +27,4 @@ type SSHClientOptions struct {
 	User              string
 	DialTimeout       time.Duration
 	KeepaliveInterval time.Duration
-	KeepaliveTimeout  time.Duration
 }

--- a/tunnel/tunnel_normal.go
+++ b/tunnel/tunnel_normal.go
@@ -93,6 +93,7 @@ func (t NormalTunnel) Start(ctx context.Context, options TunnelOptions) error {
 	if err != nil {
 		return errors.Wrap(err, "resolve tunnel listen addr")
 	}
+
 	// Listen for incoming tunnel connections.
 	st.WithEventTags(stats.Tags{"listen_addr": listenAddr}).SimpleEvent("listener.start")
 	listener, err := net.ListenTCP("tcp", listenTcpAddr)
@@ -120,8 +121,7 @@ func (t NormalTunnel) Start(ctx context.Context, options TunnelOptions) error {
 			default:
 				// Accept incoming tunnel connections
 				conn, err := listener.AcceptTCP()
-				if err != nil && !isContextCancelled(ctx) {
-					t.logger().WithError(err).Error("tunnel conn accept error")
+				if err != nil {
 					break
 				}
 


### PR DESCRIPTION
- Go `net` pkg builtin keepalive
- Apply keep-alive to tunnel connections
- Propagate errors during copy