### PR TITLE
Normal Tunnel Visibility & Networking

### DIFF
--- a/cmd/passage/application.go
+++ b/cmd/passage/application.go
@@ -286,6 +286,8 @@ func newConfig() (*viper.Viper, error) {
 func newLogger(config *viper.Viper) *logrus.Logger {
 	logger := logrus.New()
 	switch config.GetString(ConfigLogLevel) {
+	case "trace":
+		logger.SetLevel(logrus.TraceLevel)
 	case "debug":
 		logger.SetLevel(logrus.DebugLevel)
 	case "info":

--- a/cmd/passage/server.go
+++ b/cmd/passage/server.go
@@ -41,7 +41,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 }
 
 // runTunnels is the entrypoint for tunnel servers
-func runTunnels(lc fx.Lifecycle, server tunnel.API, sql *sqlx.DB, config *viper.Viper, keystore keystore.Keystore, healthchecks *healthcheckManager, st stats.Stats) error {
+func runTunnels(lc fx.Lifecycle, server tunnel.API, sql *sqlx.DB, config *viper.Viper, keystore keystore.Keystore, healthchecks *healthcheckManager, st stats.Stats, logger *logrus.Logger) error {
 	// Helper function for initializing a tunnel.Manager
 	runTunnelManager := func(name string, listFunc tunnel.ListFunc) {
 		manager := tunnel.NewManager(
@@ -71,6 +71,7 @@ func runTunnels(lc fx.Lifecycle, server tunnel.API, sql *sqlx.DB, config *viper.
 		runTunnelManager(tunnel.Normal, tunnel.InjectNormalTunnelDependencies(server.GetNormalTunnels, tunnel.NormalTunnelServices{
 			SQL:      postgres.NewClient(sql),
 			Keystore: keystore,
+			Logger:   logger,
 		}, tunnel.SSHClientOptions{
 			User:              config.GetString(ConfigTunnelNormalSshUser),
 			DialTimeout:       config.GetDuration(ConfigTunnelNormalDialTimeout),
@@ -88,6 +89,7 @@ func runTunnels(lc fx.Lifecycle, server tunnel.API, sql *sqlx.DB, config *viper.
 		runTunnelManager(tunnel.Reverse, tunnel.InjectReverseTunnelDependencies(server.GetReverseTunnels, tunnel.ReverseTunnelServices{
 			SQL:      postgres.NewClient(sql),
 			Keystore: keystore,
+			Logger:   logger,
 		}, tunnel.SSHServerOptions{
 			BindHost: config.GetString(ConfigTunnelReverseBindHost),
 			HostKey:  hostKey,

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -47,6 +47,10 @@ type Event struct {
 	Tags Tags
 }
 
+func (s Stats) Count(name string, value int64, tags Tags, rate float64) {
+	s.client.Count(joinPrefixes(s.prefix, name), value, convertTags(mergeTags([]Tags{s.tags, tags})), rate)
+}
+
 func (s Stats) Incr(name string, tags Tags, rate float64) {
 	s.client.Incr(joinPrefixes(s.prefix, name), convertTags(mergeTags([]Tags{s.tags, tags})), rate)
 }

--- a/tunnel/conncheck.go
+++ b/tunnel/conncheck.go
@@ -31,7 +31,7 @@ type CheckTunnelResponse struct {
 
 // CheckTunnel identifies a currently running tunnel, gets connection details, and attempts a connection
 func (s API) CheckTunnel(ctx context.Context, req CheckTunnelRequest) (*CheckTunnelResponse, error) {
-	s.Stats.SimpleEvent("status_check")
+	s.Stats.WithTags(stats.Tags{"tunnel_id": req.ID}).SimpleEvent("status_check")
 	details, err := s.GetTunnel(ctx, GetTunnelRequest{ID: req.ID})
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get connection details")

--- a/tunnel/tunnel_normal.go
+++ b/tunnel/tunnel_normal.go
@@ -189,13 +189,13 @@ func (t NormalTunnel) Start(ctx context.Context, options TunnelOptions) error {
 					st.SimpleEvent("accept")
 					defer st.SimpleEvent("close")
 
-					// Register connection for visibility.
-					tunnelRegistry.RegisterConnection(sessionId, time.Now())
-					defer tunnelRegistry.DeregisterConnection(sessionId)
-
 					// Configure networking parameters.
 					tunnelConn.SetKeepAlive(true)
 					tunnelConn.SetKeepAlivePeriod(t.clientOptions.KeepaliveInterval)
+
+					// Register connection for visibility.
+					tunnelRegistry.RegisterConnection(sessionId, time.Now())
+					defer tunnelRegistry.DeregisterConnection(sessionId)
 
 					// Connect upstream and forward bytes
 					read, written, err := t.handleTunnelConnection(stats.InjectContext(ctx, st), sshClient, tunnelConn)
@@ -278,7 +278,7 @@ func (t NormalTunnel) getAuthSigners(ctx context.Context) ([]ssh.Signer, error) 
 			return []ssh.Signer{}, errors.Wrapf(err, "could not parse key %s", key.ID)
 		}
 
-		t.logger().WithField("fingerprint", ssh.FingerprintSHA256(signer.PublicKey())).Debug("using ssh key")
+		t.logger().WithField("fingerprint", ssh.FingerprintSHA256(signer.PublicKey())).Debug("upstream connection with SSH key")
 		signers[i] = signer
 	}
 

--- a/tunnel/tunnel_normal.go
+++ b/tunnel/tunnel_normal.go
@@ -3,14 +3,12 @@ package tunnel
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"github.com/hightouchio/passage/stats"
 	"github.com/hightouchio/passage/tunnel/discovery"
 	"github.com/hightouchio/passage/tunnel/keystore"
-	"io"
 	"net"
 	"strconv"
-	"sync/atomic"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -130,8 +128,16 @@ func (t NormalTunnel) Start(ctx context.Context, options TunnelOptions) error {
 		}
 	}()
 
-	// Report active connections every tick
-	var activeConnections int32
+	// Keep record of active connections.
+	tunnelConns := connectionRegistry{
+		conns: make(map[uuid.UUID]tunnelConnection),
+	}
+	reportTunnelConnections := func() {
+		tunnelConns.mux.RLock()
+		defer tunnelConns.mux.RUnlock()
+		st.WithTags(stats.Tags{"tunnel_id": t.ID.String()}).Gauge("active_connections", float64(len(tunnelConns.conns)), nil, 1)
+	}
+
 	go func() {
 		statsTicker := time.NewTicker(1 * time.Second)
 		defer statsTicker.Stop()
@@ -141,9 +147,9 @@ func (t NormalTunnel) Start(ctx context.Context, options TunnelOptions) error {
 			case <-ctx.Done():
 				return
 
+				// Report tunnel state on every tick
 			case <-statsTicker.C:
-				tActiveConns := atomic.LoadInt32(&activeConnections)
-				st.WithTags(stats.Tags{"tunnel_id": t.ID.String()}).Gauge("active_connections", float64(tActiveConns), nil, 1)
+				reportTunnelConnections()
 			}
 		}
 	}()
@@ -159,29 +165,34 @@ func (t NormalTunnel) Start(ctx context.Context, options TunnelOptions) error {
 				go func() {
 					defer tunnelConn.Close()
 
+					sessionId := uuid.New()
 					st := st.WithEventTags(stats.Tags{
 						"remote_addr": tunnelConn.RemoteAddr().String(),
-						"session_id":  uuid.New(),
+						"session_id":  sessionId,
 					}).WithPrefix("conn")
 					st.SimpleEvent("accept")
-					st.Incr("accept", nil, 1)
-					atomic.AddInt32(&activeConnections, 1)
+					defer st.SimpleEvent("close")
 
-					// Configure keepalive
+					// Register connection for visibility.
+					tunnelConns.RegisterConnection(sessionId, time.Now())
+					defer tunnelConns.DeregisterConnection(sessionId)
+
+					// Configure networking parameters.
 					tunnelConn.SetKeepAlive(true)
 					tunnelConn.SetKeepAlivePeriod(t.clientOptions.KeepaliveInterval)
-					// Tunnel connection
+
+					// Connect upstream and forward bytes
 					read, written, err := t.handleTunnelConnection(stats.InjectContext(ctx, st), sshClient, tunnelConn)
 
-					atomic.AddInt32(&activeConnections, -1)
-					// TODO: This is probably wrong because its overriding a shared value.
+					// Record bytes read and written on
 					st = st.WithEventTags(stats.Tags{"read_bytes": read, "write_bytes": written})
 					st.Gauge("read_bytes", float64(read), nil, 1)
 					st.Gauge("write_bytes", float64(written), nil, 1)
 
-					// Handle connection handle error
+					// Handle connection errors
 					if err != nil {
 						switch err.(type) {
+						// Handle errors in which we couldn't even connect to the upstream port
 						case upstreamConnectionError:
 							// Set SO_LINGER=0 so the TCP connection does not perform a graceful shutdown, indicating that the upstream couldn't be reached.
 							if err := tunnelConn.SetLinger(0); err != nil {
@@ -192,8 +203,6 @@ func (t NormalTunnel) Start(ctx context.Context, options TunnelOptions) error {
 						st.ErrorEvent("error", err)
 						return
 					}
-
-					st.SimpleEvent("close")
 				}()
 			}
 		}
@@ -209,73 +218,28 @@ func (t NormalTunnel) Start(ctx context.Context, options TunnelOptions) error {
 	return nil
 }
 
-// upstreamConnectionError wraps an error connecting to an upstream service
-type upstreamConnectionError struct {
-	err error
+// tunnelConnection is a representation of an active connection for visibility
+type tunnelConnection struct {
+	startAt time.Time
 }
 
-func (e upstreamConnectionError) Error() string {
-	return fmt.Sprintf("could not connect to upstream: %s", e.err.Error())
+type connectionRegistry struct {
+	conns map[uuid.UUID]tunnelConnection
+	mux   sync.RWMutex
 }
 
-// handleTunnelConnection handles incoming TCP connections on the tunnel listen port, dials the tunneled upstream, and copies bytes bidirectionally
-func (t NormalTunnel) handleTunnelConnection(ctx context.Context, sshClient *ssh.Client, tunnelConn net.Conn) (r, w int64, err error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	st := stats.GetStats(ctx)
-
-	// Dial upstream service.
-	upstreamAddr := net.JoinHostPort(t.ServiceHost, strconv.Itoa(t.ServicePort))
-	st.WithEventTags(stats.Tags{"upstream_addr": upstreamAddr}).SimpleEvent("upstream.dial")
-	serviceConn, err := sshClient.Dial("tcp", upstreamAddr)
-	if err != nil {
-		// Return upstreamConnectionError to indicate that the connection should be forcibly closed.
-		return 0, 0, upstreamConnectionError{err: err}
-	}
-	defer serviceConn.Close()
-
-	// Pass data bidirectionally from tunnel to service net.Conn, wait for errors, and record read/write
-	done := make(chan struct{})
-	go func() {
-		r, w, err = bidirectionalReadWrite(tunnelConn, serviceConn)
-		close(done)
-	}()
-
-	// Wait for completion or for context cancellation
-	select {
-	case <-done:
-		return
-	case <-ctx.Done():
-		return
+func (r *connectionRegistry) RegisterConnection(sessionId uuid.UUID, startAt time.Time) {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+	r.conns[sessionId] = tunnelConnection{
+		startAt: startAt,
 	}
 }
 
-func bidirectionalReadWrite(a, b io.ReadWriter) (ra, rb int64, err error) {
-	copyConn := func(src io.Reader, dst io.Writer, written *int64, errors chan<- error) {
-		byteCount, err := io.Copy(dst, src)
-		*written = byteCount // Record number of bytes written in this direction
-		errors <- err
-	}
-
-	// Copy data bidirectionally.
-	errA := make(chan error)
-	go copyConn(a, b, &ra, errA)
-	errB := make(chan error)
-	go copyConn(b, a, &rb, errB)
-
-	// Wait for either side A or B to close, and return ero
-	select {
-	case err = <-errA:
-		if err != nil {
-			err = errors.Wrap(err, "read A")
-		}
-	case err = <-errB:
-		if err != nil {
-			err = errors.Wrap(err, "read B")
-		}
-	}
-
-	return
+func (r *connectionRegistry) DeregisterConnection(sessionId uuid.UUID) {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+	delete(r.conns, sessionId)
 }
 
 // getAuthSigners finds the SSH keys that are configured for this tunnel and structure them for use by the SSH client library

--- a/tunnel/tunnel_normal_net.go
+++ b/tunnel/tunnel_normal_net.go
@@ -123,7 +123,9 @@ func logNormalTunnelInstanceState(i *normalTunnelInstance, st stats.Stats, logge
 	}
 
 	st.Gauge("active_connections", float64(len(i.conns)), nil, 1)
-	logger.WithField("active_connections", ids).Trace("tunnel active connections")
+	if len(i.conns) > 0 {
+		logger.WithField("active_connections", ids).Trace("tunnel active connections")
+	}
 }
 
 // BidirectionalPipeline passes bytes bidirectionally from io.ReadWriters a and b, and records the number of bytes written to each.

--- a/tunnel/tunnel_normal_net.go
+++ b/tunnel/tunnel_normal_net.go
@@ -41,9 +41,9 @@ func (i *normalTunnelInstance) HandleConnection(ctx context.Context, conn *net.T
 	bytesWritten = new(int64)
 	defer func() {
 		// Record pipeline metrics to logs and statsd
-		st.WithEventTags(stats.Tags{"read_bytes": *bytesRead, "write_bytes": *bytesWritten}).SimpleEvent("close")
 		st.Count("read_bytes", *bytesRead, nil, 1)
 		st.Count("write_bytes", *bytesWritten, nil, 1)
+		st.WithEventTags(stats.Tags{"read_bytes": *bytesRead, "write_bytes": *bytesWritten}).SimpleEvent("close")
 	}()
 
 	// Register connection for visibility.

--- a/tunnel/tunnel_normal_net.go
+++ b/tunnel/tunnel_normal_net.go
@@ -1,0 +1,81 @@
+package tunnel
+
+import (
+	"context"
+	"fmt"
+	"github.com/hightouchio/passage/stats"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/ssh"
+	"io"
+	"net"
+	"strconv"
+)
+
+// handleTunnelConnection handles incoming TCP connections on the tunnel listen port, dials the tunneled upstream, and copies bytes bidirectionally
+func (t NormalTunnel) handleTunnelConnection(ctx context.Context, sshClient *ssh.Client, tunnelConn net.Conn) (r, w int64, err error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	st := stats.GetStats(ctx)
+
+	// Dial upstream service.
+	upstreamAddr := net.JoinHostPort(t.ServiceHost, strconv.Itoa(t.ServicePort))
+	st.WithEventTags(stats.Tags{"upstream_addr": upstreamAddr}).SimpleEvent("upstream.dial")
+	serviceConn, err := sshClient.Dial("tcp", upstreamAddr)
+	if err != nil {
+		// Return upstreamConnectionError to indicate that the connection should be forcibly closed.
+		return 0, 0, upstreamConnectionError{err: err}
+	}
+	defer serviceConn.Close()
+
+	// Pass data bidirectionally from tunnel to service net.Conn, wait for errors, and record read/write
+	done := make(chan struct{})
+	go func() {
+		r, w, err = bidirectionalReadWrite(tunnelConn, serviceConn)
+		close(done)
+	}()
+
+	// Wait for completion or for context cancellation
+	select {
+	case <-done:
+		return
+	case <-ctx.Done():
+		return
+	}
+}
+
+// upstreamConnectionError wraps an error connecting to an upstream service
+type upstreamConnectionError struct {
+	err error
+}
+
+func (e upstreamConnectionError) Error() string {
+	return fmt.Sprintf("could not connect to upstream: %s", e.err.Error())
+}
+
+func bidirectionalReadWrite(a, b io.ReadWriter) (ra, rb int64, err error) {
+	copyConn := func(src io.Reader, dst io.Writer, written *int64, errors chan<- error) {
+		byteCount, err := io.Copy(dst, src)
+		*written = byteCount // Record number of bytes written in this direction
+		errors <- err
+	}
+
+	// Copy data bidirectionally.
+	errA := make(chan error)
+	go copyConn(a, b, &ra, errA)
+	errB := make(chan error)
+	go copyConn(b, a, &rb, errB)
+
+	// Wait for either side A or B to close, and return ero
+	select {
+	case err = <-errA:
+		if err != nil {
+			err = errors.Wrap(err, "read A")
+		}
+	case err = <-errB:
+		if err != nil {
+			err = errors.Wrap(err, "read B")
+		}
+	}
+
+	return
+}

--- a/tunnel/tunnel_reverse.go
+++ b/tunnel/tunnel_reverse.go
@@ -228,7 +228,7 @@ func (t ReverseTunnel) GetID() uuid.UUID {
 }
 
 func (t ReverseTunnel) logger() *logrus.Entry {
-	return logrus.WithFields(logrus.Fields{
+	return t.services.Logger.WithFields(logrus.Fields{
 		"tunnel_type": Reverse,
 		"tunnel_id":   t.ID.String(),
 	})

--- a/tunnel/tunnel_reverse.go
+++ b/tunnel/tunnel_reverse.go
@@ -183,6 +183,7 @@ type ReverseTunnelServices struct {
 		GetReverseTunnelAuthorizedKeys(ctx context.Context, tunnelID uuid.UUID) ([]postgres.Key, error)
 	}
 	Keystore keystore.Keystore
+	Logger   *logrus.Logger
 }
 
 func InjectReverseTunnelDependencies(f func(ctx context.Context) ([]ReverseTunnel, error), services ReverseTunnelServices, options SSHServerOptions) ListFunc {


### PR DESCRIPTION
Upgrades to normal tunnel networking & visibility.

**Networking**
- Hard close connections when upstream connection fails (`SO_LINGER 0`)
- Refactor bidirectional port forwarding code to handle errors more clearly.

**Visibility**
- Associate session ID with each active connection.
- Log state of active connections.
