### PR TITLE
Expose tunnel error to DB

### DIFF
--- a/tunnel/conncheck.go
+++ b/tunnel/conncheck.go
@@ -42,7 +42,11 @@ func (s API) CheckTunnel(ctx context.Context, req CheckTunnelRequest) (*CheckTun
 
 	if err := checkConnectivity(ctx, details.ConnectionDetails); err != nil {
 		s.Stats.Incr("status_check", stats.Tags{"success": false}, 1)
-		return &CheckTunnelResponse{Success: false, Error: err.Error()}, nil
+		errorMessage := "Failed to connect to tunnel"
+		if details.Tunnel.GetError() != nil {
+			errorMessage = *details.Tunnel.GetError()
+		}
+		return &CheckTunnelResponse{Success: false, Error: errorMessage}, nil
 	}
 
 	s.Stats.Incr("status_check", stats.Tags{"success": true}, 1)

--- a/tunnel/manager_test.go
+++ b/tunnel/manager_test.go
@@ -127,3 +127,7 @@ func (m *mockTunnel) Equal(i interface{}) bool {
 	}
 	return m.id == v.id && m.port == v.port
 }
+
+func (m *mockTunnel) GetError() *string {
+	return nil
+}

--- a/tunnel/postgres/keys.go
+++ b/tunnel/postgres/keys.go
@@ -69,3 +69,14 @@ func (c Client) AuthorizeKeyForTunnel(ctx context.Context, tunnelType string, tu
 	}
 	return nil
 }
+
+const updateErrorForNormalTunnel = `
+UPDATE passage.tunnels set error = $1 where id = $2
+`
+
+func (c Client) UpdateNormalTunnelError(ctx context.Context, tunnelID uuid.UUID, error string) error {
+	if _, err := c.db.ExecContext(ctx, updateErrorForNormalTunnel, error, tunnelID.String()); err != nil {
+		return err
+	}
+	return nil
+}

--- a/tunnel/postgres/migrations/3_add_error_column_tunnel.down.sql
+++ b/tunnel/postgres/migrations/3_add_error_column_tunnel.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE passage.tunnels DROP COLUMN error;
+ALTER TABLE passage.reverse_tunnels DROP COLUMN error;

--- a/tunnel/postgres/migrations/3_add_error_column_tunnel.up.sql
+++ b/tunnel/postgres/migrations/3_add_error_column_tunnel.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE passage.tunnels ADD COLUMN IF NOT EXISTS error text;
+ALTER TABLE passage.reverse_tunnels ADD COLUMN IF NOT EXISTS error text;

--- a/tunnel/postgres/tunnel_reverse.go
+++ b/tunnel/postgres/tunnel_reverse.go
@@ -10,12 +10,13 @@ import (
 )
 
 type ReverseTunnel struct {
-	ID         uuid.UUID    `db:"id"`
-	CreatedAt  time.Time    `db:"created_at"`
-	Enabled    bool         `db:"enabled"`
-	TunnelPort int          `db:"tunnel_port"`
-	SSHDPort   int          `db:"sshd_port"`
-	LastUsedAt sql.NullTime `db:"last_used_at"`
+	ID         uuid.UUID      `db:"id"`
+	CreatedAt  time.Time      `db:"created_at"`
+	Enabled    bool           `db:"enabled"`
+	TunnelPort int            `db:"tunnel_port"`
+	SSHDPort   int            `db:"sshd_port"`
+	LastUsedAt sql.NullTime   `db:"last_used_at"`
+	Error      sql.NullString `db:"error"`
 }
 
 func (c Client) CreateReverseTunnel(ctx context.Context, input ReverseTunnel) (ReverseTunnel, error) {

--- a/tunnel/postgres/tunnel_standard.go
+++ b/tunnel/postgres/tunnel_standard.go
@@ -21,6 +21,7 @@ type NormalTunnel struct {
 	SSHPort     int            `db:"ssh_port"`
 	ServiceHost string         `db:"service_host"`
 	ServicePort int            `db:"service_port"`
+	Error       sql.NullString `db:"error"`
 }
 
 func (c Client) CreateNormalTunnel(ctx context.Context, input NormalTunnel) (NormalTunnel, error) {

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -14,6 +14,7 @@ type Tunnel interface {
 
 	GetID() uuid.UUID
 	Equal(interface{}) bool
+	GetError() *string
 }
 
 type TunnelOptions struct {

--- a/tunnel/tunnel_normal_net.go
+++ b/tunnel/tunnel_normal_net.go
@@ -61,7 +61,6 @@ func (i *normalTunnelInstance) HandleConnection(ctx context.Context, conn *net.T
 		if err := conn.SetLinger(0); err != nil {
 			st.ErrorEvent("error", errors.Wrap(err, "error SetLinger"))
 		}
-
 		st.ErrorEvent("error", errors.Wrap(err, "upstream connection error"))
 		return
 	}

--- a/tunnel/tunnel_reverse.go
+++ b/tunnel/tunnel_reverse.go
@@ -21,8 +21,9 @@ type ReverseTunnel struct {
 	CreatedAt time.Time `json:"createdAt"`
 	Enabled   bool      `json:"enabled"`
 
-	SSHDPort   int `json:"sshdPort"`
-	TunnelPort int `json:"tunnelPort"`
+	SSHDPort   int     `json:"sshdPort"`
+	TunnelPort int     `json:"tunnelPort"`
+	Error      *string `json:"error"`
 
 	services      ReverseTunnelServices
 	serverOptions SSHServerOptions
@@ -232,4 +233,8 @@ func (t ReverseTunnel) logger() *logrus.Entry {
 		"tunnel_type": Reverse,
 		"tunnel_id":   t.ID.String(),
 	})
+}
+
+func (t ReverseTunnel) GetError() *string {
+	return t.Error
 }


### PR DESCRIPTION
This PR adds the ability to persist tunnel error into database so that we can surface any tunnel error to users. Right now it only persists normal tunnel error. (For reverse tunnel it is a bit of tricky as most of connection information happens on client side which is initializing the connection).

- It adds `error` column to `passage.tunnels` and `passage.reverse_tunnels`
- It persist any start error when session is started in normal tunnel. Once connection is successfully established, it will empty the error.
- When doing healthcheck on the tunnel, it returns the error from db which will be used to surface it to end users.