### PR TITLE
Use SHA2 algorithms for generating SSH signatures with RSA keys

### DIFF
--- a/tunnel/signer.go
+++ b/tunnel/signer.go
@@ -1,0 +1,39 @@
+package tunnel
+
+import (
+	"github.com/gliderlabs/ssh"
+	gossh "golang.org/x/crypto/ssh"
+	"io"
+)
+
+// wrapSigner wraps a signer and overrides its public key type with the provided algorithm
+type wrapSigner struct {
+	ssh.Signer
+	algorithm string
+}
+
+// PublicKey returns an associated PublicKey instance.
+func (s *wrapSigner) PublicKey() gossh.PublicKey {
+	return &wrapPublicKey{
+		PublicKey: s.Signer.PublicKey(),
+		algorithm: s.algorithm,
+	}
+}
+
+// Sign returns raw signature for the given data. This method
+// will apply the hash specified for the keytype to the data using
+// the algorithm assigned for this key
+func (s *wrapSigner) Sign(rand io.Reader, data []byte) (*gossh.Signature, error) {
+	return s.Signer.(gossh.AlgorithmSigner).SignWithAlgorithm(rand, data, s.algorithm)
+}
+
+// wrapPublicKey wraps a PublicKey and overrides its type
+type wrapPublicKey struct {
+	gossh.PublicKey
+	algorithm string
+}
+
+// Type returns the algorithm
+func (k *wrapPublicKey) Type() string {
+	return k.algorithm
+}


### PR DESCRIPTION
OpenSSH 8.2 deprecated SHA1 and by default rejects requests where the RSA signature is generated using SHA1. The Go crypto library, like a lot of other libraries, assumes that the key types (RSA, EDCSA etc.) have a 1:1 mapping with supported algorithms. This used to be true until RSA added SHA256 and SHA512 (SHA2 algorithms). This PR aims to address Go's limitations by adding a wrapper around the existing signers and adding signatures that use SHA2. 