### PR TITLE
Convert unique constraint on key_authorization to primary key

### DIFF
--- a/tunnel/postgres/migrations/2_initialize_schema.up.sql
+++ b/tunnel/postgres/migrations/2_initialize_schema.up.sql
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS passage.key_authorizations(
     tunnel_type passage.tunnel_type NOT NULL,
     tunnel_id   UUID NOT NULL,
 
+    -- This is converted to a primary key in a later migration.
     UNIQUE(key_id, tunnel_type, tunnel_id)
 );
 

--- a/tunnel/postgres/migrations/5_key_authorizations_pk.down.sql
+++ b/tunnel/postgres/migrations/5_key_authorizations_pk.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE passage.key_authorizations ADD CONSTRAINT key_authorizations_key_id_tunnel_type_tunnel_id_key UNIQUE (key_id, tunnel_type, tunnel_id);
+ALTER TABLE passage.key_authorizations DROP CONSTRAINT IF EXISTS key_authorizations_pkey;
+
+COMMIT;

--- a/tunnel/postgres/migrations/5_key_authorizations_pk.up.sql
+++ b/tunnel/postgres/migrations/5_key_authorizations_pk.up.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.constraint_table_usage
+    WHERE table_schema = 'passage'
+    AND table_name = 'key_authorizations'
+    AND constraint_name = 'key_authorizations_pkey'
+  ) THEN
+    ALTER TABLE passage.key_authorizations ADD PRIMARY KEY(key_id, tunnel_type, tunnel_id);
+  END IF;
+END $$;
+
+ALTER TABLE passage.key_authorizations DROP CONSTRAINT IF EXISTS key_authorizations_key_id_tunnel_type_tunnel_id_key;
+
+COMMIT:


### PR DESCRIPTION
Primary keys are better for logical replication.