### PR TITLE
Memory/goroutine leak in tunnel listener healthcheck

### DIFF
--- a/tunnel/status.go
+++ b/tunnel/status.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"io"
-	"io/ioutil"
 	"net"
 	"time"
 )

--- a/tunnel/status_test.go
+++ b/tunnel/status_test.go
@@ -1,0 +1,1 @@
+package tunnel

--- a/tunnel/status_test.go
+++ b/tunnel/status_test.go
@@ -1,1 +1,0 @@
-package tunnel


### PR DESCRIPTION
The **tunnel listener check** runs in a loop to check the health of a tunnel network listener. It opens a TCP connection to the listener and reads a bit of data. If either of these steps fail, an error is recorded and tunnel healthchecks are updated.

The tunnel listener check has a built-in timeout feature. The caller specifies a timeout `time.Duration`, and if that duration elapses before a connection is established, or before data is read, the check returns early with a timeout error.

After the network connection is established, we spawn a goroutine to read from that connection. If an error is returned, that goroutine sends the error to the parent goroutine via a `chan error`.

There is a bug with this timeout behavior. When the timeout elapses, we close the `net.Conn`, which triggers an error on the downstream call to `io.Read`. However, we _return early_ with the timeout error (from `ctx.Err()`), and therefore there is nothing to receive from the channel where the _reader error_ is being sent.

As a result, the goroutine dedicated to receiving read errors and sending them upstream _blocks on the channel send_, and never returns. This causes the program to leak goroutines and `errors` allocated on the heap.

This PR fixes this problem by short-circuiting the send of the error to the channel if the parent context has been cancelled. Basically, if we've already timed out (or the context was cancelled for whatever reason), don't worry about sending the error upstream, just drop it.