### PR TITLE
Simplify listener test

### DIFF
--- a/tunnel/status.go
+++ b/tunnel/status.go
@@ -140,10 +140,17 @@ func testUpstream(ctx context.Context, fn GetUpstreamFn) error {
 	errchan := make(chan error)
 	go func() {
 		upstream, err := fn()
-		errchan <- err
+
 		if upstream != nil {
-			defer upstream.Close()
+			upstream.Close()
 		}
+
+		// If the context has closed before we receive an error, short circuit
+		if ctx.Err() != nil {
+			return
+		}
+
+		errchan <- err
 	}()
 
 	select {


### PR DESCRIPTION
There's a memory leak with the listener test, and its not really necessary anymore that we have a dedicated test for the upstream.

Additionally, remove a memory leak in the upstream test, similar to [the one fixed earlier](https://github.com/hightouchio/passage/pull/50).