### PR TITLE
Stream tunnel data transfer rates to stats

### DIFF
--- a/tunnel/server.go
+++ b/tunnel/server.go
@@ -28,7 +28,7 @@ func TCPServeStrategy(bindHost string, serviceDiscovery discovery.Service, retry
 		if err != nil {
 			return errors.Wrap(err, "open listener")
 		}
-		logger.Debugw("Start listener", "listen_addr", tunnelListener.Addr().String())
+		logger.Debugw("Start listener", zap.String("addr", tunnelListener.Addr().String()))
 		defer tunnelListener.Close()
 
 		// Register tunnel with service discovery.


### PR DESCRIPTION
Right now, tunnels only report the total number of bytes sent/received when a connection ends. This change makes it so tunnels continuously stream their data transfer rates as the connection progresses.