### PR TITLE
Continous tunnel connection metrics reporting

### DIFF
--- a/tunnel/forwarder.go
+++ b/tunnel/forwarder.go
@@ -222,14 +222,14 @@ type CountedReadWriteCloser struct {
 }
 
 func (c *CountedReadWriteCloser) Read(p []byte) (n int, err error) {
-	bytesRead, err := c.Read(p)
+	bytesRead, err := c.ReadWriteCloser.Read(p)
 	c.bytesRead += uint64(bytesRead)
 	return bytesRead, err
 }
 
 func (c *CountedReadWriteCloser) Write(p []byte) (n int, err error) {
 	c.bytesWritten += uint64(len(p))
-	return c.Write(p)
+	return c.ReadWriteCloser.Write(p)
 }
 
 func (c *CountedReadWriteCloser) GetBytesWritten() uint64 {

--- a/tunnel/forwarder.go
+++ b/tunnel/forwarder.go
@@ -75,7 +75,7 @@ func (f *TCPForwarder) Serve() error {
 	var connectionCount atomic.Int32
 	go intervalMetricReporter(ctx, func() {
 		// Report the current client connection count
-		stats.GetStats(ctx).Gauge(StatTunnelClientActiveConnectionCount, float64(connectionCount.Load()), stats.Tags{}, 1)
+		f.Stats.Gauge(StatTunnelClientActiveConnectionCount, float64(connectionCount.Load()), stats.Tags{}, 1)
 	})
 
 	for {

--- a/tunnel/forwarder.go
+++ b/tunnel/forwarder.go
@@ -146,6 +146,7 @@ func (f *TCPForwarder) handleSession(ctx context.Context, session *TCPSession, s
 
 	// Stream connection stats to the aggregator
 	go func() {
+		// Record connection stats every second and report deltas to the aggregator
 		ticker := time.NewTicker(1 * time.Second)
 		defer ticker.Stop()
 		connectionStatProducer(ctx, sessionRwc, upstreamRwc, statReports, ticker.C)
@@ -274,8 +275,6 @@ func connectionStatAggregator(
 	tick <-chan time.Time,
 ) {
 	var agg ConnectionStatsPayload
-
-	// TODO: Maybe we want to do a bit of internal batching rather than calling the report func on each delta?
 
 	for {
 		select {

--- a/tunnel/forwarder_test.go
+++ b/tunnel/forwarder_test.go
@@ -1,6 +1,39 @@
 package tunnel
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
-func TestBidirectionalPipeline_Run(t *testing.T) {
+func Test_reportStats(t *testing.T) {
+	ticker := make(chan time.Time)
+
+	var payloads *[]ConnectionStatsPayload
+
+	go reportStats(func() []ConnectionStatsPayload {
+		return *payloads
+	}, ticker)
+
+	payloads = &[]ConnectionStatsPayload{
+		{
+			ClientBytesSent:     100,
+			ClientBytesReceived: 100,
+		},
+	}
+
+	ticker <- time.Now()
+
+	payloads = &[]ConnectionStatsPayload{
+		{
+			ClientBytesSent:     200,
+			ClientBytesReceived: 100,
+		},
+
+		{
+			ClientBytesSent:     500,
+			ClientBytesReceived: 500,
+		},
+	}
+
+	ticker <- time.Now()
 }

--- a/tunnel/stats.go
+++ b/tunnel/stats.go
@@ -2,7 +2,6 @@ package tunnel
 
 import (
 	"context"
-	"github.com/hightouchio/passage/stats"
 	"time"
 )
 
@@ -21,21 +20,6 @@ const (
 	StatSshdConnectionsRequests          = "passage.sshd.connection_requests"
 	StatSshReversePortForwardingRequests = "passage.sshd.forwarding_connection_requests"
 )
-
-type ConnectionStatsPayload struct {
-	ClientBytesSent       uint64
-	ClientBytesReceived   uint64
-	UpstreamBytesSent     uint64
-	UpstreamBytesReceived uint64
-}
-
-// reportTunnelConnectionStats reports the number of bytes read and written to the statsd client
-func reportTunnelConnectionStats(st stats.Stats, payload ConnectionStatsPayload) {
-	st.Count(StatTunnelClientBytesSent, int64(payload.ClientBytesSent), stats.Tags{}, 1)
-	st.Count(StatTunnelClientBytesReceived, int64(payload.ClientBytesReceived), stats.Tags{}, 1)
-	st.Count(StatTunnelUpstreamBytesSent, int64(payload.UpstreamBytesSent), stats.Tags{}, 1)
-	st.Count(StatTunnelUpstreamBytesReceived, int64(payload.UpstreamBytesReceived), stats.Tags{}, 1)
-}
 
 // Standardized metric reporting interval
 const metricReportInterval = 1 * time.Second

--- a/tunnel/stats.go
+++ b/tunnel/stats.go
@@ -1,10 +1,31 @@
 package tunnel
 
+import "github.com/hightouchio/passage/stats"
+
 const (
-	StatTunnelCount         = "passage.tunnel.count"
-	StatTunnelBytesReceived = "passage.tunnel.bytes_rcvd"
-	StatTunnelBytesSent     = "passage.tunnel.bytes_sent"
+	StatTunnelCount = "passage.tunnel.count"
+
+	StatTunnelClientBytesSent     = "passage.tunnel.client.bytes_sent"
+	StatTunnelClientBytesReceived = "passage.tunnel.client.bytes_rcvd"
+
+	StatTunnelUpstreamBytesSent     = "passage.tunnel.upstream.bytes_sent"
+	StatTunnelUpstreamBytesReceived = "passage.tunnel.upstream.bytes_rcvd"
 
 	StatSshdConnectionsRequests          = "passage.sshd.connection_requests"
 	StatSshReversePortForwardingRequests = "passage.sshd.reverse_port_forwarding_requests"
 )
+
+type ConnectionStatsPayload struct {
+	ClientBytesSent       uint64
+	ClientBytesReceived   uint64
+	UpstreamBytesSent     uint64
+	UpstreamBytesReceived uint64
+}
+
+// reportTunnelConnectionStats reports the number of bytes read and written to the statsd client
+func reportTunnelConnectionStats(st stats.Stats, payload ConnectionStatsPayload) {
+	st.Count(StatTunnelClientBytesSent, int64(payload.ClientBytesSent), stats.Tags{}, 1)
+	st.Count(StatTunnelClientBytesReceived, int64(payload.ClientBytesReceived), stats.Tags{}, 1)
+	st.Count(StatTunnelUpstreamBytesSent, int64(payload.UpstreamBytesSent), stats.Tags{}, 1)
+	st.Count(StatTunnelUpstreamBytesReceived, int64(payload.UpstreamBytesReceived), stats.Tags{}, 1)
+}

--- a/tunnel/stats_test.go
+++ b/tunnel/stats_test.go
@@ -113,9 +113,9 @@ func Test_StatReporter(t *testing.T) {
 	tickAgg()
 
 	assert.Equal(t, forwarderStatsPayload{
-		ClientBytesSent:       512,
-		ClientBytesReceived:   975,
-		UpstreamBytesSent:     975,
-		UpstreamBytesReceived: 512,
+		ClientBytesSent:       377,
+		ClientBytesReceived:   800,
+		UpstreamBytesSent:     800,
+		UpstreamBytesReceived: 377,
 	}, <-report)
 }

--- a/tunnel/stats_test.go
+++ b/tunnel/stats_test.go
@@ -24,7 +24,7 @@ type fakeConnectionPair struct {
 	tick           func()
 }
 
-func fakePair(ctx context.Context, deltas chan<- ConnectionStatsPayload) fakeConnectionPair {
+func fakePair(ctx context.Context, deltas chan<- forwarderStatsPayload) fakeConnectionPair {
 	client := &fakeConnection{}
 	server := &fakeConnection{}
 
@@ -54,7 +54,7 @@ func Test_StatReporter(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	deltas := make(chan ConnectionStatsPayload)
+	deltas := make(chan forwarderStatsPayload)
 
 	// Create three connection pairs to simulate metric aggregation
 	pair1 := fakePair(ctx, deltas)
@@ -68,8 +68,8 @@ func Test_StatReporter(t *testing.T) {
 	}
 
 	// Consume the aggregated reports
-	report := make(chan ConnectionStatsPayload)
-	go connectionStatAggregator(ctx, deltas, func(stats ConnectionStatsPayload) {
+	report := make(chan forwarderStatsPayload)
+	go connectionStatAggregator(ctx, deltas, func(stats forwarderStatsPayload) {
 		report <- stats
 	}, tickAggC)
 
@@ -91,7 +91,7 @@ func Test_StatReporter(t *testing.T) {
 	tickAgg()
 
 	// Assert current state of the result
-	assert.Equal(t, ConnectionStatsPayload{
+	assert.Equal(t, forwarderStatsPayload{
 		ClientBytesSent:       135,
 		ClientBytesReceived:   175,
 		UpstreamBytesSent:     175,
@@ -112,7 +112,7 @@ func Test_StatReporter(t *testing.T) {
 
 	tickAgg()
 
-	assert.Equal(t, ConnectionStatsPayload{
+	assert.Equal(t, forwarderStatsPayload{
 		ClientBytesSent:       512,
 		ClientBytesReceived:   975,
 		UpstreamBytesSent:     975,

--- a/tunnel/stats_test.go
+++ b/tunnel/stats_test.go
@@ -1,0 +1,121 @@
+package tunnel
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+type fakeConnection struct {
+	bytesWritten, bytesRead uint64
+}
+
+func (f *fakeConnection) GetBytesWritten() uint64 {
+	return f.bytesWritten
+}
+
+func (f *fakeConnection) GetBytesRead() uint64 {
+	return f.bytesRead
+}
+
+type fakeConnectionPair struct {
+	client, server *fakeConnection
+	tick           func()
+}
+
+func fakePair(ctx context.Context, deltas chan<- ConnectionStatsPayload) fakeConnectionPair {
+	client := &fakeConnection{}
+	server := &fakeConnection{}
+
+	tick := make(chan time.Time)
+	go connectionStatProducer(ctx, client, server, deltas, tick)
+
+	return fakeConnectionPair{
+		client: client,
+		server: server,
+		tick: func() {
+			tick <- time.Now()
+		},
+	}
+}
+
+func (p fakeConnectionPair) clientWrite(bytes uint64) {
+	p.client.bytesWritten += bytes
+	p.server.bytesRead += bytes
+}
+
+func (p fakeConnectionPair) serverWrite(bytes uint64) {
+	p.client.bytesRead += bytes
+	p.server.bytesWritten += bytes
+}
+
+func Test_StatReporter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	deltas := make(chan ConnectionStatsPayload)
+
+	// Create three connection pairs to simulate metric aggregation
+	pair1 := fakePair(ctx, deltas)
+	pair2 := fakePair(ctx, deltas)
+	pair3 := fakePair(ctx, deltas)
+
+	// Create a ticker to control the aggregator
+	tickAggC := make(chan time.Time)
+	tickAgg := func() {
+		tickAggC <- time.Now()
+	}
+
+	// Consume the aggregated reports
+	report := make(chan ConnectionStatsPayload)
+	go connectionStatAggregator(ctx, deltas, func(stats ConnectionStatsPayload) {
+		report <- stats
+	}, tickAggC)
+
+	// Total of 135 bytes written by the client, 175 bytes written by the server
+	pair1.clientWrite(10)
+	pair1.tick()
+
+	pair2.serverWrite(50)
+	pair2.tick()
+
+	pair3.serverWrite(125)
+	pair3.clientWrite(125)
+	pair3.tick()
+
+	// Sleep so the deltas are consumed
+	time.Sleep(300 * time.Millisecond)
+
+	// Tick the aggregator
+	tickAgg()
+
+	// Assert current state of the result
+	assert.Equal(t, ConnectionStatsPayload{
+		ClientBytesSent:       135,
+		ClientBytesReceived:   175,
+		UpstreamBytesSent:     175,
+		UpstreamBytesReceived: 135,
+	}, <-report)
+
+	pair2.clientWrite(350)
+	pair2.serverWrite(250)
+	pair2.tick()
+
+	pair3.serverWrite(50)
+	pair3.serverWrite(500)
+	pair3.clientWrite(27)
+	pair3.tick()
+
+	// Sleep so the deltas are consumed
+	time.Sleep(1000 * time.Millisecond)
+
+	tickAgg()
+
+	assert.Equal(t, ConnectionStatsPayload{
+		ClientBytesSent:       512,
+		ClientBytesReceived:   975,
+		UpstreamBytesSent:     975,
+		UpstreamBytesReceived: 512,
+	}, <-report)
+}

--- a/tunnel/status.go
+++ b/tunnel/status.go
@@ -200,20 +200,17 @@ func listenerHealthcheck(
 	)
 }
 
-const (
-	healthcheckDialTimeout = 5 * time.Second
-)
-
 // testListener dials the listener to confirm that its open
 func testListener(ctx context.Context, addr net.Addr) error {
-	dialer := &net.Dialer{
-		Timeout: healthcheckDialTimeout,
-	}
-	conn, err := dialer.DialContext(ctx, "tcp", addr.String())
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
+	// TODO: Re-enable
+	//dialer := &net.Dialer{
+	//	Timeout: healthcheckDialTimeout,
+	//}
+	//conn, err := dialer.DialContext(ctx, "tcp", addr.String())
+	//if err != nil {
+	//	return err
+	//}
+	//defer conn.Close()
 
 	return nil
 }

--- a/tunnel/status.go
+++ b/tunnel/status.go
@@ -28,7 +28,7 @@ const (
 	statusHealthcheckID       = "tunnel"
 	statusHealthcheckName     = "Tunnel"
 	statusHealthcheckTTL      = 180 * time.Second
-	statusHealthcheckInterval = 15 * time.Second
+	statusHealthcheckInterval = 20 * time.Second
 )
 
 // intervalStatusReporter sends regular status updates to a StatusUpdate channel
@@ -92,7 +92,7 @@ const (
 	upstreamHealthcheckID       = "upstream"
 	upstreamHealthcheckName     = "Upstream reachability"
 	upstreamHealthcheckTTL      = 180 * time.Second
-	upstreamHealthcheckInterval = 15 * time.Second
+	upstreamHealthcheckInterval = 60 * time.Second
 )
 
 // upstreamHealthcheck reports the health of the upstream service to service discovery
@@ -164,8 +164,8 @@ func testUpstream(ctx context.Context, fn GetUpstreamFn) error {
 const (
 	listenerHealthcheckID       = "listener"
 	listenerHealthcheckName     = "Listener reachability"
-	listenerHealthcheckTTL      = 60 * time.Second
-	listenerHealthcheckInterval = 15 * time.Second
+	listenerHealthcheckTTL      = 180 * time.Second
+	listenerHealthcheckInterval = 60 * time.Second
 )
 
 // listenerHealthcheck continuously checks the status of the tunnel listener

--- a/tunnel/status.go
+++ b/tunnel/status.go
@@ -28,7 +28,7 @@ const (
 	statusHealthcheckID       = "tunnel"
 	statusHealthcheckName     = "Tunnel"
 	statusHealthcheckTTL      = 180 * time.Second
-	statusHealthcheckInterval = 20 * time.Second
+	statusHealthcheckInterval = 15 * time.Second
 )
 
 // intervalStatusReporter sends regular status updates to a StatusUpdate channel
@@ -92,7 +92,7 @@ const (
 	upstreamHealthcheckID       = "upstream"
 	upstreamHealthcheckName     = "Upstream reachability"
 	upstreamHealthcheckTTL      = 180 * time.Second
-	upstreamHealthcheckInterval = 60 * time.Second
+	upstreamHealthcheckInterval = 15 * time.Second
 )
 
 // upstreamHealthcheck reports the health of the upstream service to service discovery
@@ -164,8 +164,8 @@ func testUpstream(ctx context.Context, fn GetUpstreamFn) error {
 const (
 	listenerHealthcheckID       = "listener"
 	listenerHealthcheckName     = "Listener reachability"
-	listenerHealthcheckTTL      = 180 * time.Second
-	listenerHealthcheckInterval = 60 * time.Second
+	listenerHealthcheckTTL      = 60 * time.Second
+	listenerHealthcheckInterval = 15 * time.Second
 )
 
 // listenerHealthcheck continuously checks the status of the tunnel listener

--- a/tunnel/status.go
+++ b/tunnel/status.go
@@ -200,17 +200,20 @@ func listenerHealthcheck(
 	)
 }
 
+const (
+	healthcheckDialTimeout = 5 * time.Second
+)
+
 // testListener dials the listener to confirm that its open
 func testListener(ctx context.Context, addr net.Addr) error {
-	// TODO: Re-enable
-	//dialer := &net.Dialer{
-	//	Timeout: healthcheckDialTimeout,
-	//}
-	//conn, err := dialer.DialContext(ctx, "tcp", addr.String())
-	//if err != nil {
-	//	return err
-	//}
-	//defer conn.Close()
+	dialer := &net.Dialer{
+		Timeout: healthcheckDialTimeout,
+	}
+	conn, err := dialer.DialContext(ctx, "tcp", addr.String())
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
 
 	return nil
 }

--- a/tunnel/tunnel_reverse.go
+++ b/tunnel/tunnel_reverse.go
@@ -74,6 +74,12 @@ func (t ReverseTunnel) Start(ctx context.Context, listener *net.TCPListener, sta
 		}
 	})
 
+	// Regularly report server-wide stats
+	go intervalMetricReporter(ctx, func() {
+		// Report the current client connection count
+		stats.GetStats(ctx).Gauge(StatTunnelReverseForwardClientConnectionCount, float64(connectionCount.Load()), stats.Tags{}, 1)
+	})
+
 	// Handle incoming SSH port forwarding connections
 	logger.Info("Tunnel registered with SSH server. Waiting for connections")
 	connWg := sync.WaitGroup{}


### PR DESCRIPTION
Collect metrics on bytes sent/received for both the client and upstream side connections. Aggregate those metrics on a per-tunnel basis, and report the metrics to a statsd server on a regular basis.